### PR TITLE
Performance Improvements

### DIFF
--- a/data/fusion_scripts/antiAugments.lua
+++ b/data/fusion_scripts/antiAugments.lua
@@ -1,5 +1,7 @@
 script.on_internal_event(Defines.InternalEvents.GET_AUGMENTATION_VALUE,
 function(ShipManager, AugName, AugValue)
+  --For some reason, Hyperspace.ships(1) crashes when AugName == "CARGO_SLOT"
+  if AugName == "CARGO_SLOT" or AugName == nil or ShipManager == nil or AugValue == nil then return Defines.Chain.CONTINUE, AugValue end
   if AugName:sub(0, 8) ~= "ANTIAUG_" and ShipManager then
     local OtherShipManager = Hyperspace.ships(1 - ShipManager.iShipId)
     if OtherShipManager then

--- a/data/fusion_scripts/callbacks.lua
+++ b/data/fusion_scripts/callbacks.lua
@@ -1,6 +1,100 @@
 local vter = mods.fusion.vter
 local real_projectile = mods.fusion.real_projectile
 local randomInt = mods.fusion.randomInt
+mods.fusion.system_ids = {}
+local fusion = mods.fusion
+
+mods.fusion.system_ids.SYS_SHIELDS = 0
+mods.fusion.system_ids.SYS_ENGINES = 1
+mods.fusion.system_ids.SYS_OXYGEN = 2
+mods.fusion.system_ids.SYS_WEAPONS = 3
+mods.fusion.system_ids.SYS_DRONES = 4
+mods.fusion.system_ids.SYS_MEDBAY = 5
+mods.fusion.system_ids.SYS_PILOT = 6
+mods.fusion.system_ids.SYS_SENSORS = 7
+mods.fusion.system_ids.SYS_DOORS = 8
+mods.fusion.system_ids.SYS_TELEPORTER = 9
+mods.fusion.system_ids.SYS_CLOAKING = 10
+mods.fusion.system_ids.SYS_ARTILLERY = 11
+mods.fusion.system_ids.SYS_BATTERY = 12
+mods.fusion.system_ids.SYS_CLONEBAY = 13
+mods.fusion.system_ids.SYS_MIND = 14
+mods.fusion.system_ids.SYS_HACKING = 15
+mods.fusion.system_ids.SYS_TEMPORAL = 20
+
+--todo these are not all the fields
+---@class (Exact) FireEvent
+---@field name string
+---@field systemId number 
+---@field add function
+---@field setupFunction function
+---@field usageRequested boolean
+
+---@class (Exact) SystemEvent
+---@field name string
+---@field add function
+
+local FireEventIds = {WEAPON_FIRE="Defines.FireEvents.WEAPON_FIRE",
+                      ARTILLERY_FIRE="Defines.FireEvents.ARTILLERY_FIRE"
+}
+
+local SystemEventIds = {ON_ACTIVATE="Defines.SystemEvents.ON_ACTIVATE",
+                      ON_SHUTDOWN="Defines.SystemEvents.ON_SHUTDOWN",
+                      ON_RUN="Defines.SystemEvents.ON_RUN"
+}
+
+local mTrackedSystemIds = {}
+
+
+local function createWeaponsLoop()
+  script.on_internal_event(Defines.InternalEvents.ON_TICK,
+    function()
+      for i = 0, 1 do
+        local weapons = nil
+        local ship = Hyperspace.ships(i)
+        pcall(function() weapons = ship.weaponSystem.weapons end)
+        if weapons and ship.weaponSystem:Powered() then 
+          for weapon in vter(weapons) do
+            while true do
+              local projectile = weapon:GetProjectile()
+              if projectile then
+                Hyperspace.Global.GetInstance():GetCApp().world.space.projectiles:push_back(projectile)
+                Defines.FireEvents.WEAPON_FIRE(ship, weapon, projectile)
+              else
+                break
+              end
+            end
+          end
+        end
+      end
+    end, 1000)
+end
+
+local function createArtilleryLoop()
+  script.on_internal_event(Defines.InternalEvents.ON_TICK,
+    function()
+      for i = 0, 1 do
+        local artilleries = nil
+        local ship = Hyperspace.ships(i)
+        pcall(function() artilleries = ship.artillerySystems end)
+        if artilleries then 
+          for artillery in vter(artilleries) do
+            while true do
+              local weapon = artillery.projectileFactory
+              local projectile = weapon:GetProjectile()
+              if projectile then
+                Hyperspace.Global.GetInstance():GetCApp().world.space.projectiles:push_back(projectile)
+                Defines.FireEvents.ARTILLERY_FIRE(ship, artillery, projectile)
+              else
+                break
+              end
+            end
+          end
+        end
+      end
+    end, 1000)
+end
+
 
 local callback_runner = {
     identifier = "",
@@ -19,7 +113,7 @@ local callback_runner = {
     end
   end,
 
-  add = function(self, func, priority)
+  add = function(self, func, systemId, priority)
     local priority = priority or 0
     if type(priority) ~= 'number' or math.floor(priority) ~= priority then
       error("Priority argument must be an integer!", 3)
@@ -31,16 +125,21 @@ local callback_runner = {
         ptab = v break
       end
     end
-    if not ptab then 
-      ptab = setmetatable({}, {priority = priority}) 
-      table.insert(self, ptab) 
+    if not ptab then
+      ptab = setmetatable({}, {priority = priority})
+      table.insert(self, ptab)
     end
     if type(func) ~= 'function' then
       error("Second argument must be a function!", 3)
     end
-    table.insert(ptab, func)
+    local function wrapperFunc(ShipManager, System) --Wrap function to only call it if it's triggered by the associated system.
+       if systemId == System:GetId() then
+          return func(ShipManager, System)
+       end
+    end
+    table.insert(ptab, wrapperFunc)
     table.sort(self,
-    function(lesser,greater) 
+    function(lesser,greater)
       return getmetatable(lesser).priority > getmetatable(greater).priority --larger numbers come first
     end)
   end,
@@ -53,12 +152,26 @@ local callback_runner = {
   end,
 }
 
+---These events only work with systems with timers and cooldowns.
+---ON_ACTIVATE Called the first frame a system is activated
+---ON_RUN     Called every non-first frame a system is active
+---ON_SHUTDOWN Called when an active system becomes inactive.
 Defines.SystemEvents = {
-  ON_ACTIVATE = callback_runner:new({identifier = "Defines.SystemEvents.ON_ACTIVATE"}),
-  ON_SHUTDOWN = callback_runner:new({identifier = "Defines.SystemEvents.ON_SHUTDOWN"}),
-  ON_RUN = callback_runner:new({identifier = "Defines.SystemEvents.ON_RUN"}),
+  ON_ACTIVATE = callback_runner:new({identifier = SystemEventIds[ON_ACTIVATE]}),
+  ON_SHUTDOWN = callback_runner:new({identifier = SystemEventIds[ON_SHUTDOWN]}),
+  ON_RUN = callback_runner:new({identifier = SystemEventIds[ON_RUN]}),
 }
 
+---WEAPON_FIRE  Called whenever a weapon fires
+---ARTILLERY_FIRE Called whenever an artillery fires
+Defines.FireEvents = {
+  WEAPON_FIRE = callback_runner:new({identifier = FireEventIds[WEAPON_FIRE]}),
+  ARTILLERY_FIRE = callback_runner:new({identifier = FireEventIds[ARTILLERY_FIRE]}),
+}
+Defines.FireEvents.WEAPON_FIRE.setupFunction = createWeaponsLoop
+Defines.FireEvents.ARTILLERY_FIRE.setupFunction = createArtilleryLoop
+Defines.FireEvents.WEAPON_FIRE.systemId = mods.fusion.system_ids.SYS_ARTILLERY
+Defines.FireEvents.ARTILLERY_FIRE.systemId = mods.fusion.system_ids.SYS_WEAPONS
 
 local system_callbacks = {
   name="",
@@ -66,10 +179,10 @@ local system_callbacks = {
   procedure = function(self)
     for i = 0, 1 do
       local sys = nil
-      pcall(function() 
-        if type(self.name) == 'string' then  
+      pcall(function()
+        if type(self.name) == 'string' then
           sys = Hyperspace.ships(i)[self.name]
-        else 
+        else
           sys = Hyperspace.ships(i):GetSystem(self.name)
         end
       end)
@@ -77,14 +190,17 @@ local system_callbacks = {
         if sys.iLockCount == -1 then --if the system is locked
           if not self.just_on[i] then-- if the system is locked and was not activated last frame, meaning it was just turned on
             Defines.SystemEvents.ON_ACTIVATE(Hyperspace.ships(i), sys)
+            --print("on activate triggered for", sys)
           end
           self.just_on[i] = true
           if not Hyperspace.Global.GetInstance():GetCApp().world.space.gamePaused then
+            --print("on run triggered for", sys)
             Defines.SystemEvents.ON_RUN(Hyperspace.ships(i), sys)
           end
         elseif self.just_on[i] then --if the system was locked (meaning activated) last frame and is no longer locked
           self.just_on[i] = false
           Defines.SystemEvents.ON_SHUTDOWN(Hyperspace.ships(i), sys)
+            --print("on shutdown triggered for", sys)
         end
       end
     end
@@ -101,78 +217,47 @@ local system_callbacks = {
   end,
 }
 
-system_callbacks:new('teleportSystem')
-system_callbacks:new('cloakSystem')
-system_callbacks:new('batterySystem')
-system_callbacks:new('mindSystem')
-system_callbacks:new('hackingSystem')
-system_callbacks:new(20) --custom system, can only be accessed by numerical identifier
-
-
-
-
-function script.on_system_event(SystemEvent, func, priority)
+---comment
+---@deprecated This method causes high resource usage, use script.on_specific_system_event instead.
+---@param SystemEvent SystemEvent
+---@param SystemId number
+---@param func function that takes arguments ShipManager, System
+---@param priority number higher priority functions are applied first
+local function on_system_event(SystemEvent, SystemId, func, priority)
   local validEvent = false
   for _, v in pairs(Defines.SystemEvents) do
     if v == SystemEvent then validEvent = true break end
   end
   if not validEvent then
     log("\n\nValid SystemEvents:\nON_ACTIVATE\nON_SHUTDOWN\nON_RUN")
-    error("First argument of function 'script.on_system_event' must be a valid SystemEvent! Check the FTL_HS.log file for more information.", 2)
+    error("First argument of function 'on_system_event' must be a valid SystemEvent! Check the FTL_HS.log file for more information.", 2)
   end
-  SystemEvent:add(func, priority)
+  SystemEvent:add(func, SystemId, priority)
 end
 
-Defines.FireEvents = {
-  WEAPON_FIRE = callback_runner:new({identifier = "Defines.FireEvents.WEAPON_FIRE"}),
-  ARTILLERY_FIRE = callback_runner:new({identifier = "Defines.FireEvents.ARTILLERY_FIRE"}),
-}
-script.on_internal_event(Defines.InternalEvents.ON_TICK,
-function()
-  for i = 0, 1 do
-    local weapons = nil
-    local ship = Hyperspace.ships(i)
-    pcall(function() weapons = ship.weaponSystem.weapons end)
-    if weapons and ship.weaponSystem:Powered() then 
-      for weapon in vter(weapons) do
-        while true do
-          local projectile = weapon:GetProjectile()
-          if projectile then
-            Hyperspace.Global.GetInstance():GetCApp().world.space.projectiles:push_back(projectile)
-            Defines.FireEvents.WEAPON_FIRE(ship, weapon, projectile)
-          else
-            break
-          end
-        end
-      end
-    end
+--#region ----------API-------------
+
+---Creates a listener for a specific system event on a specific system.
+---There is no additional overhead cost for registering multiple events on the same system,
+---but it does cost more to register multiple systems.
+---
+---This only supports systems that have some kind of activated ability, as activations are what these events track.
+---@param SystemEvent SystemEvent
+---@param SystemId number
+---@param func function that takes arguments ShipManager, System
+---@param priority number higher priority functions are applied first
+function fusion.on_specific_system_event(SystemEvent, SystemId, func, priority)
+  if not mTrackedSystemIds[SystemId] then
+    system_callbacks:new(SystemId)
+    mTrackedSystemIds[SystemId] = true
   end
-end, 1000)
+  on_system_event(SystemEvent, SystemId, func, priority)
+end
 
-script.on_internal_event(Defines.InternalEvents.ON_TICK,
-function()
-  for i = 0, 1 do
-    local artilleries = nil
-    local ship = Hyperspace.ships(i)
-    pcall(function() artilleries = ship.artillerySystems end)
-    if artilleries then 
-      for artillery in vter(artilleries) do
-        while true do
-          local weapon = artillery.projectileFactory
-          local projectile = weapon:GetProjectile()
-          if projectile then
-            Hyperspace.Global.GetInstance():GetCApp().world.space.projectiles:push_back(projectile)
-            Defines.FireEvents.ARTILLERY_FIRE(ship, artillery, projectile)
-          else
-            break
-          end
-        end
-      end
-    end
-  end
-end, 1000)
-
-
+---
+---@param FireEvent FireEvent
+---@param func function that takes arguments ShipManager, Weapon, Projectile
+---@param priority number higher priority functions are applied first
 function script.on_fire_event(FireEvent, func, priority)
   local validEvent = false
   for _, v in pairs(Defines.FireEvents) do
@@ -182,5 +267,11 @@ function script.on_fire_event(FireEvent, func, priority)
     log("\n\nValid FireEvents:\nWEAPON_FIRE\nARTILLERY_FIRE")
     error("First argument of function 'script.on_fire_event' must be a valid FireEvent! Check the FTL_HS.log file for more information.", 2)
   end
-  FireEvent:add(func, priority)
+
+  print(FireEvent.name, FireEvent.add, FireEvent.setupFunction, FireEvent.usageRequested)
+  if not FireEvent.usageRequested then
+    FireEvent.setupFunction()
+  end
+  FireEvent:add(func, FireEvent.systemId, priority)
 end
+--#endregion -------------------------------------------

--- a/data/fusion_scripts/custom_fires.lua
+++ b/data/fusion_scripts/custom_fires.lua
@@ -8,6 +8,10 @@ local FIRE_GRID_HEIGHT = 40 --Height of the fireSpreader grid
 local SMOKE_ANIMATION_DURATION = 1 --Length of vanilla smoke animation, in seconds
 local FIRE_ANIMATION_DURATION = 1 --Length of vanilla fire animation, in seconds
 
+local vanillaSheet = Hyperspace.Resources:GetImageId("effects/largeFire.png")
+local get_fire_extend
+local mSetupRequested = false
+
 --Globally visible constants table
 local constants = setmetatable({}, {
   __newindex = function() error("Attempt to modify a read-only table", 2) end,
@@ -38,78 +42,6 @@ local function fires(room, shipManager)
       end
   end   
 end
- 
---EXTENDED FIRE IMPLEMENTATION
-local Fire_Extend = {}
-function Fire_Extend:New()
-  local fire_extend = {
-
-    systemDamageMultiplier = 1,
-    spreadSpeedMultiplier = 1,
-    deathSpeedMultiplier = 1,
-    oxygenDrainMultiplier = 1,
-    animationSpeedMultiplier = 1,
-    replacementSheet = nil,
-  }
-  return setmetatable(fire_extend, {__index = Fire_Extend})
-end
-
-function Fire_Extend:Reset()
-  self.systemDamageMultiplier = 1
-  self.spreadSpeedMultiplier = 1
-  self.deathSpeedMultiplier = 1
-  self.oxygenDrainMultiplier = 1
-  self.animationSpeedMultiplier = 1
-  self.replacementSheet = nil
-end
-
-local fireExtends = {[0] = {}, [1] = {}}
-local function get_fire_idx(fire)
-  local x = fire.pLoc.x // 35
-  local y = fire.pLoc.y // 35
-  return math.floor(y * FIRE_GRID_WIDTH + x)
-end
-
---Return a table that corresponds to a fire
-local function get_fire_extend(fire)
-  local argType = swig_type(fire)
-  local expectedType = "Fire *"
-  if argType ~= expectedType then
-    local errorMessage = string.format("Error in get_fire_extend: Expected arg of type: %s, recieved arg of type: %s", expectedType, argType)
-    error(errorMessage, 2) 
-  end
-
-  local extend = fireExtends[fire.shipObj.iShipId][get_fire_idx(fire)]
-  if extend == nil then
-    error("No extended object for fire!", 2)
-  end
-  return extend
-end
-
---Table construction/cleanup
-
---Rooms are not initialized in ShipManager construction, so the actual setup has to take place in SHIP_LOOP
-script.on_internal_event(Defines.InternalEvents.CONSTRUCT_SHIP_MANAGER, 
-function(shipManager)
-  --Free old table and mark for setup
-  fireExtends[shipManager.iShipId] = nil 
-end)
-
-script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, 
-function(shipManager)
-  if fireExtends[shipManager.iShipId] == nil then
-  --Create new table
-    local extends = {}
-    for room in vter(shipManager.ship.vRoomList) do
-      for fire in fires(room, shipManager) do
-        local idx = get_fire_idx(fire)
-          extends[idx] = Fire_Extend:New()
-      end
-    end
-    fireExtends[shipManager.iShipId] = extends
-  end
-end, constants.FIRE_EXTEND_INITIALIZATION_LOOP_PRIORITY)
-
 
 --FIRE MECHANICAL IMPLEMENTATION
 
@@ -159,18 +91,8 @@ local function accelerate_animation(animation, speed, base_time)
   animation:SetProgress(progress)
 end
 
---Reset fire values on tick
-script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, 
-function(shipManager)
-  for room in vter(shipManager.ship.vRoomList) do
-    for fire in fires(room, shipManager) do
-      get_fire_extend(fire):Reset()
-    end
-  end
-end, constants.FIRE_STAT_INITIALIZATION_PRIORITY)
-local vanillaSheet = Hyperspace.Resources:GetImageId("effects/largeFire.png")
-script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, 
-function(shipManager)
+local function customFireLoop(shipManager)
+  if shipManager == nil then return end
   for room in vter(shipManager.ship.vRoomList) do
     local timeDilation = Hyperspace.TemporalSystemParser.GetDilationStrength(room.extend.timeDilation)
     local fireCount = shipManager:GetFireCount(room.iRoomId)
@@ -244,6 +166,101 @@ function(shipManager)
       end
     end
   end
+end
+
+--EXTENDED FIRE IMPLEMENTATION
+local Fire_Extend = {}
+function Fire_Extend:New()
+  local fire_extend = {
+
+    systemDamageMultiplier = 1,
+    spreadSpeedMultiplier = 1,
+    deathSpeedMultiplier = 1,
+    oxygenDrainMultiplier = 1,
+    animationSpeedMultiplier = 1,
+    replacementSheet = nil,
+  }
+  return setmetatable(fire_extend, {__index = Fire_Extend})
+end
+
+function Fire_Extend:Reset()
+  self.systemDamageMultiplier = 1
+  self.spreadSpeedMultiplier = 1
+  self.deathSpeedMultiplier = 1
+  self.oxygenDrainMultiplier = 1
+  self.animationSpeedMultiplier = 1
+  self.replacementSheet = nil
+end
+
+local fireExtends = {[0] = {}, [1] = {}}
+local function get_fire_idx(fire)
+  local x = fire.pLoc.x // 35
+  local y = fire.pLoc.y // 35
+  return math.floor(y * FIRE_GRID_WIDTH + x)
+end
+
+
+--Return a table that corresponds to a fire
+get_fire_extend = function(fire)
+  if not mSetupRequested then
+    mSetupRequested = true
+    customFireLoop(Hyperspace.ships(fire.shipObj.iShipId))
+  end
+  local argType = swig_type(fire)
+  local expectedType = "Fire *"
+  if argType ~= expectedType then
+    local errorMessage = string.format("Error in get_fire_extend: Expected arg of type: %s, recieved arg of type: %s", expectedType, argType)
+    error(errorMessage, 2) 
+  end
+
+  local extend = fireExtends[fire.shipObj.iShipId][get_fire_idx(fire)]
+  if extend == nil then
+    error("No extended object for fire!", 2)
+  end
+  return extend
+end
+
+--Table construction/cleanup
+
+--Rooms are not initialized in ShipManager construction, so the actual setup has to take place in SHIP_LOOP
+script.on_internal_event(Defines.InternalEvents.CONSTRUCT_SHIP_MANAGER, 
+function(shipManager)
+  --Free old table and mark for setup
+  fireExtends[shipManager.iShipId] = nil 
+end)
+
+script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, 
+function(shipManager)
+  if fireExtends[shipManager.iShipId] == nil then
+  --Create new table
+    local extends = {}
+    for room in vter(shipManager.ship.vRoomList) do
+      for fire in fires(room, shipManager) do
+        local idx = get_fire_idx(fire)
+          extends[idx] = Fire_Extend:New()
+      end
+    end
+    fireExtends[shipManager.iShipId] = extends
+  end
+end, constants.FIRE_EXTEND_INITIALIZATION_LOOP_PRIORITY)
+
+
+
+--Reset fire values on tick
+script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, 
+function(shipManager)
+  if not mSetupRequested then return end
+  for room in vter(shipManager.ship.vRoomList) do
+    for fire in fires(room, shipManager) do
+      get_fire_extend(fire):Reset()
+    end
+  end
+end, constants.FIRE_STAT_INITIALIZATION_PRIORITY)
+
+script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, 
+function(shipManager)
+  if not mSetupRequested then return end
+  return customFireLoop(shipManager)
 end, constants.FIRE_STAT_APPLICATION_PRIORITY)
 --TODO: Implement fires with crew damage and crew repair multipliers once lua statboosts are active
 

--- a/data/fusion_scripts/dialogueBoxes.lua
+++ b/data/fusion_scripts/dialogueBoxes.lua
@@ -1,6 +1,6 @@
 local dialogueBox = mods.fusion.dialogueBox
 
-tutorialBox = dialogueBox:New {
+local tutorialBox = dialogueBox:New {
   font = 1, --The font that the dialogue is rendered in
   x = 300, --x coordinate of the top-left corner of the dialogue box
   y = 100, --y coordinate of the top left corner of the dialogue box

--- a/data/fusion_scripts/drones.lua
+++ b/data/fusion_scripts/drones.lua
@@ -7,7 +7,7 @@ mods.fusion.chainDrones.DRONE_MISSILES={scaling=0.1, max="10"}
 script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, function(ShipManager)
     local combatdrones = ShipManager.spaceDrones
     local speed = ShipManager:GetAugmentationValue("FR_NEXUS_DRONES_BOOST")
-    if ShipManager:HasAugmentation("FR_NEXUS_DRONES_BOOST") > 0 then 
+    if ShipManager:HasAugmentation("FR_NEXUS_DRONES_BOOST") > 0 then
         for combatdrone in vter(combatdrones) do
             if combatdrone.powered then
                 if combatdrone.currentSpeed and combatdrone.weaponCooldown >= 0 then

--- a/data/fusion_scripts/systems.lua
+++ b/data/fusion_scripts/systems.lua
@@ -1,52 +1,91 @@
 local vter = mods.fusion.vter
 local real_projectile = mods.fusion.real_projectile
 local randomInt = mods.fusion.randomInt
-
-script.on_system_event(
-    Defines.SystemEvents.ON_SHUTDOWN,
-    function(ship, sys) 
-      if sys:GetId() == 14 then
-        sys:LockSystem(4)
-      end
-    end,
-    2147483647)--priority
+local fusion = mods.fusion
 
 local COOLDOWN_AUGS = {
-  [9] = "FAST_TELEPORT",
-  [10] = "FAST_CLOAK",
-  [12] = "FAST_BATTERY",
-  [14] = "FAST_MIND",
-  [15] = "FAST_HACK",
-  [20] = "FAST_TEMPORAL",
+  [fusion.system_ids.SYS_TELEPORTER] = "FAST_TELEPORT",
+  [fusion.system_ids.SYS_CLOAKING] = "FAST_CLOAK",
+  [fusion.system_ids.SYS_BATTERY] = "FAST_BATTERY",
+  [fusion.system_ids.SYS_MIND] = "FAST_MIND",
+  [fusion.system_ids.SYS_HACKING] = "FAST_HACK",
+  [fusion.system_ids.SYS_TEMPORAL] = "FAST_TEMPORAL"
 }
 
-script.on_system_event(
-  Defines.SystemEvents.ON_SHUTDOWN,
-  function(ship, sys)
-    local augName = COOLDOWN_AUGS[sys:GetId()]
-    local speedup = math.floor(ship:GetAugmentationValue(augName))
-    local newlock = math.max(sys.iLockCount - speedup, 0)
-    sys:LockSystem(newlock)
-  end,
- -1000)
+local function cooldownAugCallback(ship, sys)
+  local augName = COOLDOWN_AUGS[sys:GetId()]
+  local speedup = math.floor(ship:GetAugmentationValue(augName))
+  local newlock = math.max(sys.iLockCount - speedup, 0)
+  sys:LockSystem(newlock)
+end
 
-script.on_system_event(Defines.SystemEvents.ON_RUN,
-function(ship, sys)
-  if sys:GetId() == 14 then
-    local increment = Hyperspace.FPS.SpeedFactor / 16
-    local modifier = 2 ^ ship:GetAugmentationValue("LONG_MIND") --Negative values make the duration shorter, longer values make it longer.
-    sys.controlTimer.first = sys.controlTimer.first + (1 / modifier - 1) * increment
+local function longMindAugCallback(ship, sys)
+  local increment = Hyperspace.FPS.SpeedFactor / 16
+  local modifier = 2 ^ ship:GetAugmentationValue("LONG_MIND") --Negative values make the duration shorter, longer values make it longer.
+  sys.controlTimer.first = sys.controlTimer.first + (1 / modifier - 1) * increment
+end
+
+local function longHackAugCallback(ship, sys)
+  local increment = Hyperspace.FPS.SpeedFactor / 16
+  local modifier = 2 ^ ship:GetAugmentationValue("LONG_HACK") --Negative values make the duration shorter, longer values make it longer.
+  sys.effectTimer.first = sys.effectTimer.first + (1 / modifier - 1) * increment
+end
+
+local function hackingDamageAugCallback(ship, sys)
+  local hackingSystem = Hyperspace.ships(ship.iShipId).hackingSystem --TODO I don't know why this doesn't work if you just pass the hacking system in.
+  local damage = ship:GetAugmentationValue("HACKING_DAMAGE")
+  if hackingSystem.currentSystem then
+    hackingSystem.currentSystem:PartialDamage(damage)
   end
+end
+
+local FUSION_AUGS = {
+  {name="FAST_TELEPORT", systemId=fusion.system_ids.SYS_TELEPORTER, registered=false, event=Defines.SystemEvents.ON_SHUTDOWN, callback=cooldownAugCallback, priority = -1000},
+  {name="FAST_CLOAK", systemId=fusion.system_ids.SYS_CLOAKING, registered=false, event=Defines.SystemEvents.ON_SHUTDOWN, callback=cooldownAugCallback, priority = -1000},
+  {name="FAST_BATTERY", systemId=fusion.system_ids.SYS_BATTERY, registered=false, event=Defines.SystemEvents.ON_SHUTDOWN, callback=cooldownAugCallback, priority = -1000},
+  {name="FAST_MIND", systemId=fusion.system_ids.SYS_MIND, registered=false, event=Defines.SystemEvents.ON_SHUTDOWN, callback=cooldownAugCallback, priority = -1000},
+  {name="FAST_HACK", systemId=fusion.system_ids.SYS_HACKING, registered=false, event=Defines.SystemEvents.ON_SHUTDOWN, callback=cooldownAugCallback, priority = -1000},
+  {name="FAST_TEMPORAL", systemId=fusion.system_ids.SYS_TEMPORAL, registered=false, event=Defines.SystemEvents.ON_SHUTDOWN, callback=cooldownAugCallback, priority = -1000},
+  {name="LONG_MIND", systemId=fusion.system_ids.SYS_MIND, registered=false, event=Defines.SystemEvents.ON_RUN, callback=longMindAugCallback, priority = 0},
+  {name="LONG_HACK", systemId=fusion.system_ids.SYS_HACKING, registered=false, event=Defines.SystemEvents.ON_RUN, callback=longHackAugCallback, priority = 0},
+  {name="HACKING_DAMAGE", systemId=fusion.system_ids.SYS_HACKING, registered=false, event=Defines.SystemEvents.ON_RUN, callback=hackingDamageAugCallback, priority = 0}
+}
+
+local function checkActiveAugs()
+  for i = 0, 1 do
+    local shipManager = Hyperspace.ships(i)
+    if not (shipManager == nil) then
+      for _,augment in ipairs(FUSION_AUGS) do
+        if not (augment.registered) then
+          if shipManager:HasAugmentation(augment.name) > 0 then
+            --print("Registering", augment.name)
+            fusion.on_specific_system_event(augment.event, augment.systemId, augment.callback, augment.priority)
+            augment.registered = true
+          end
+        end
+      end
+    end
+  end
+end
+
+--on_init doesn't guarantee that the player's ShipManager will exist, so do this instead.
+local mFirstCheckFinished = false
+script.on_internal_event(Defines.InternalEvents.ON_TICK, function()
+    local commandGui = Hyperspace.Global.GetInstance():GetCApp().gui
+    if mFirstCheckFinished or (not (Hyperspace.ships(0)) or Hyperspace.ships(0).iCustomizeMode == 2 or 
+    (commandGui.bPaused or commandGui.bAutoPaused or commandGui.event_pause or commandGui.menu_pause)) then return end
+    checkActiveAugs()
+    mFirstCheckFinished = true
 end)
 
-script.on_system_event(Defines.SystemEvents.ON_RUN,
-function(ship, sys)
-  if sys:GetId() == 15 then
-    local increment = Hyperspace.FPS.SpeedFactor / 16
-    local modifier = 2 ^ ship:GetAugmentationValue("LONG_HACK") --Negative values make the duration shorter, longer values make it longer.
-    sys.effectTimer.first = sys.effectTimer.first + (1 / modifier - 1) * increment
-  end
+-- script.on_init(function(newGame)
+--   checkActiveAugs() --todo wait until ship manager exists.  This is stupid that it doesn't.
+-- end)
+
+script.on_internal_event(Defines.InternalEvents.JUMP_ARRIVE, function (ShipManager)
+  checkActiveAugs()
 end)
+
 --[[--currently not working, battery timer not exposed
 script.on_system_event(Defines.SystemEvents.ON_RUN,
 function(ship, sys)
@@ -57,16 +96,8 @@ function(ship, sys)
   end
 end)
 --]]
-script.on_system_event(Defines.SystemEvents.ON_RUN,
-function(ship, sys)
-  if sys:GetId() == 15 then
-    local damage = ship:GetAugmentationValue("HACKING_DAMAGE")
-    sys.currentSystem:PartialDamage(damage)
-  end
-end)
 
-
-script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, 
+script.on_internal_event(Defines.InternalEvents.SHIP_LOOP,
 function(ShipManager)
   local deionizationBoost = ShipManager:GetAugmentationValue("DEIONIZATION_BOOST")
   for sys in vter(ShipManager.vSystemList) do


### PR DESCRIPTION
Adds custom_fires back to fusion, but it's only enabled it something calls into it.

Excludes CARGO_SLOT from anti_aug because it was mysteriously crashing.

Reworks FireEvents and SystemEvents to only run their code if someone has registered for the callbacks.  Removed the existing script.on_system_event and replaced it with fusion.on_specific_system_event, which takes a system id.  FireEvents are unchanged, but the fusion augments that were the only thing that uses SystemEvents (I keep almost every mod on my computer and I grepped all of them) needed a slight change to work with this new system.  As such, they are enabled when the ship jumps or the game loads.  So if you somehow get one of these augments and then have a fight in the same beacon, it wouldn't apply, but I don't really think that happens.